### PR TITLE
Allow patches, scripts and overrides in /etc/dkms

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -704,7 +704,10 @@ command.
 Each directive should specify the filename of the patch to apply, and all patches must
 be located in the patches subdirectory of your source directory (
 .I /usr/src/<module>\-<module\-version>/patches/
-). If any patch fails to apply, the build will be halted and the rejections can be
+) or in
+.I /etc/dkms/<module>/patches/
+(which takes precedence over the source directory).
+If any patch fails to apply, the build will be halted and the rejections can be
 inspected in
 .I /var/lib/dkms/<module>/<module\-version>/build/.
 If a patch should only be applied conditionally, the
@@ -846,6 +849,13 @@ of your source. If the script exits with a non\-zero value, the
 install will be aborted. This is typically used to perform a custom
 version comparison.
 .PP
+All scripts (POST_ADD, PRE_BUILD, POST_BUILD, PRE_INSTALL, POST_INSTALL, POST_REMOVE)
+can also be placed in
+.I /etc/dkms/<module>/
+instead of the module source directory. Scripts in
+.I /etc/dkms/<module>/
+take precedence over scripts in the source directory.
+.PP
 .SH DKMS.CONF VARIABLES
 Within your DKMS configuration file, you can use certain variables which will be replaced at run\-time with their values.
 .TP
@@ -881,6 +891,21 @@ file is read, dkms will look for and read the following files in order:
 You can use these files to override settings in the module-provided
 .I dkms.conf
 file.
+.PP
+Additionally, patches and scripts can be placed in
+.I /etc/dkms/<module>/
+to override those provided by the module source tree:
+.PP
+.I /etc/dkms/<module>/patches/
+\(em patch files (override same-named patches from the source directory; the
+directory structure is preserved, so patches in subdirectories such as
+.I /etc/dkms/<module>/patches/subdir/patch.patch
+will override the corresponding
+.I subdir/patch.patch
+from the source tree)
+.br
+.I /etc/dkms/<module>/
+\(em scripts referenced by PRE_BUILD, POST_BUILD, etc. (override same-named scripts from the source directory)
 .SH FRAMEWORK.CONF MAIN CONFIGURATION
 The
 .B /etc/dkms/framework.conf

--- a/dkms.in
+++ b/dkms.in
@@ -1160,12 +1160,19 @@ run_build_script() {
             script_type='source'
             ;;
     esac
-    run="$dkms_tree/$module/$module_version/$script_type/$2"
+    local run_dir
+    run_dir="$dkms_tree/$module/$module_version/$script_type"
+    run="$run_dir/$2"
+    # Check /etc/dkms/<module>/ for an override script
+    if [[ -x "/etc/dkms/$module/${2%% *}" ]]; then
+        run_dir="/etc/dkms/$module"
+        run="/etc/dkms/$module/$2"
+    fi
     if [[ -x ${run%% *} ]]; then
         if [[ $3 ]]; then
             local res
             res=0
-            invoke_command "cd $dkms_tree/$module/$module_version/$script_type/ && $run" "Running the $1 script" "$3" background || res=$?
+            invoke_command "cd $run_dir/ && $run" "Running the $1 script" "$3" background || res=$?
             if [[ $res != 0 ]]; then
                 echo "Consult $3 for more information."
                 exit "$res"
@@ -1173,7 +1180,7 @@ run_build_script() {
         else
         echo "Running the $1 script:"
         (
-            cd "$dkms_tree/$module/$module_version/$script_type/" || exit 15
+            cd "$run_dir/" || exit 15
             exec $run
         )
         fi
@@ -1563,6 +1570,12 @@ do_build()
     # Set up temporary build directory for build
     rm -rf "${build_dir:?}"
     CP -a "$source_dir/" "$build_dir"
+
+    # Overlay patches from /etc/dkms/<module>/patches/ if present
+    if [[ -d /etc/dkms/$module/patches ]]; then
+        mkdir -p "$build_dir/patches"
+        CP -a "/etc/dkms/$module/patches/." "$build_dir/patches/"
+    fi
 
     echo "DKMS (@RELEASE_STRING@) make.log for $module/$module_version for kernel $kernelver ($arch)" >> "$build_log"
     date >> "$build_log"

--- a/run_test.sh
+++ b/run_test.sh
@@ -58,6 +58,8 @@ TEST_MODULES=(
 )
 TEST_TMPDIRS=(
     "${tmpdir}/dkms_test_dir_${KERNEL_VER}/"
+    "/etc/dkms/dkms_patches_test/"
+    "/etc/dkms/dkms_scripts_test/"
 )
 TEST_TMPFILES=(
     "${tmpdir}/dkms_test_private_key"
@@ -2529,6 +2531,72 @@ EOF
 run_status_with_expected_output 'dkms_scripts_test' << EOF
 dkms_scripts_test/1.0: added
 EOF
+
+echo 'Testing patches override from /etc/dkms'
+mkdir -p /etc/dkms/dkms_patches_test/patches/subdir
+cp test/dkms_patches_test-1.0/patches/patch1.patch /etc/dkms/dkms_patches_test/patches/patch1.patch
+cp test/dkms_patches_test-1.0/patches/subdir/patch2.patch /etc/dkms/dkms_patches_test/patches/subdir/patch2.patch
+run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_patches_test -v 1.0 << EOF
+${SIGNING_PROLOGUE}
+Applying patch patch1.patch... done.
+Applying patch subdir/patch2.patch... done.
+Building module(s)... done.${SIGNING_MESSAGE_patches}
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
+Running depmod... done.
+EOF
+run_status_with_expected_output 'dkms_patches_test' << EOF
+dkms_patches_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
+EOF
+
+echo 'Unbuilding the test module with patches override'
+run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_patches_test -v 1.0 << EOF
+Module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
+Before uninstall, this module version was ACTIVE on this kernel.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
+Running depmod... done.
+EOF
+run_status_with_expected_output 'dkms_patches_test' << EOF
+dkms_patches_test/1.0: added
+EOF
+rm -rf /etc/dkms/dkms_patches_test
+
+echo 'Testing scripts override from /etc/dkms'
+mkdir -p /etc/dkms/dkms_scripts_test
+cat > /etc/dkms/dkms_scripts_test/script.sh << 'SCRIPTEOF'
+#!/bin/sh
+echo "override $*"
+exit 0
+SCRIPTEOF
+chmod +x /etc/dkms/dkms_scripts_test/script.sh
+run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_scripts_test -v 1.0 << EOF
+${SIGNING_PROLOGUE}
+Running the pre_build script... done.
+Building module(s)... done.${SIGNING_MESSAGE_scripts}
+Running the post_build script... done.
+Running the pre_install script:
+override pre_install
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
+Running the post_install script:
+override post_install
+Running depmod... done.
+EOF
+run_status_with_expected_output 'dkms_scripts_test' << EOF
+dkms_scripts_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
+EOF
+
+echo 'Unbuilding the test module with scripts override'
+run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_scripts_test -v 1.0 << EOF
+Module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
+Before uninstall, this module version was ACTIVE on this kernel.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
+Running the post_remove script:
+override post_remove
+Running depmod... done.
+EOF
+run_status_with_expected_output 'dkms_scripts_test' << EOF
+dkms_scripts_test/1.0: added
+EOF
+rm -rf /etc/dkms/dkms_scripts_test
 
 echo 'Adding noisy test module'
 run_with_expected_output dkms add test/dkms_noisy_test-1.0 << EOF


### PR DESCRIPTION
Resolves https://github.com/dkms-project/dkms/issues/562.

Overrides in `/etc/dkms`:

- Patches declared with the `PATCH[#]` directives, can now:
  - Reside in `/etc/dkms/<module>/patches/`
  - Be overridden by a patch with the same name in `/etc/dkms/<module>/patches/`
  - As before,  the directory structure is preserved, as the whole `patches` directory is copied.
- Scripts declared with `POST_ADD`, `PRE_BUILD`, `POST_BUILD`, `PRE_INSTALL`, `POST_INSTALL` and `POST_REMOVE` can now:
  - Reside in `/etc/dkms/<module>/`
  - Be overridden by a script with the same name in `/etc/dkms/<module>/`

## Examples

### Overriding a patch

Original:
```
$ ls -l /usr/src/gasket-1.0/my.patch
-rw-r--r--. 1 root root 2909 Mar  5 01:00 /usr/src/gasket-1.0/my.patch
$ cat /usr/src/gasket-1.0/dkms.conf
PATCH[0]="my.patch"
```
Override:

```
$ ls -l /etc/dkms/gasket/patches/my.patch
-rw-r--r--. 1 root root 2828 Mar 16 01:00 /etc/dkms/gasket/patches/my.patch
```

### New local patch

Adding a new local patch that survives across DKMS module upgrades:

```
$ ls -l /etc/dkms/cxr88/patches/local.patch
-rw-r--r--. 1 root root 2834 Mar 19 01:00 /etc/dkms/cxr88/patches/local.patch
$ cat /etc/dkms/cxr88.conf
PATCH[0]="local.patch"
```

### New post script

Adding a new post script that survives across DKMS module upgrades:

```
$ ls -l /etc/dkms/nvidia/scripts/reload-nvidia-peermem.sh
-rw-r--r--. 1 root root 2834 Mar 19 01:00 /etc/dkms/nvidia/scripts/reload-nvidia-peermem.sh
$ cat /etc/dkms/nvidia.conf
POST_INSTALL="reload-nvidia-peermem.sh"
```