### PR TITLE
dkms: Do not error when --rpm_safe_upgrade triggered correctly

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -2331,7 +2331,7 @@ remove_module()
             lock_tail=$(tail -n 1 "$lock_file" 2>/dev/null)
             [[ $lock_head = $module-$module_version && $time_stamp && $lock_tail = "$time_stamp" ]] || continue
             rm -f "${lock_file:?}"
-            die 0 "Remove cancelled because --rpm_safe_upgrade scenario detected."
+            diewarn 0 "Remove cancelled because --rpm_safe_upgrade scenario detected."
         done
     fi
 


### PR DESCRIPTION
When `--rpm_safe_upgrade` scenario is detected and `dkms remove` is canceled because of it, it is a correct behavior, not an error (and the exit code was indeed correctly 0). Remove the error message in such a case, and replace it with a warning, keeping the 0 exit code.