### PR TITLE
Update tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,6 @@ jobs:
           - {name: "alpine", tag: "3.22", variant: "-virt"}
           - {name: "alpine", tag: "3.21", variant: "-lts"}
           - {name: "alpine", tag: "3.21", variant: "-virt"}
-          - {name: "alpine", tag: "3.20", variant: "-lts"}
-          - {name: "alpine", tag: "3.20", variant: "-virt"}
           - {name: "archlinux", tag: "latest"}
           - {name: "archlinux", tag: "latest", variant: "-lts"}
           - {name: "archlinux", tag: "latest", variant: "-zen"}
@@ -32,7 +30,7 @@ jobs:
           - {name: "centos", tag: "stream9", url: "quay.io/centos/"}
           - {name: "debian", tag: "13"}
           - {name: "debian", tag: "12"}
-          #- {name: "fedora", tag: "rawhide", url: "registry.fedoraproject.org/"}
+          - {name: "fedora", tag: "44", url: "registry.fedoraproject.org/"}
           - {name: "fedora", tag: "43", url: "registry.fedoraproject.org/"}
           - {name: "fedora", tag: "42", url: "registry.fedoraproject.org/"}
           - {name: "gentoo/stage3", tag: "latest"}
@@ -42,11 +40,11 @@ jobs:
           - {name: "oraclelinux", tag: "10", uek: "ol10_UEKR8"}
           - {name: "oraclelinux", tag: "9", uek: "ol9_UEKR8", gcc: "gcc-toolset-14"}
           - {name: "oraclelinux", tag: "8", uek: "ol8_UEKR7", gcc: "gcc-toolset-11"}
-          - {name: "ubuntu", tag: "25.10"}
           - {name: "ubuntu", tag: "26.04"}
+          - {name: "ubuntu", tag: "25.10"}
           - {name: "ubuntu", tag: "24.04"}
           - {name: "ubuntu", tag: "22.04"}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container:
       image: ${{ matrix.distro.url }}${{ matrix.distro.name }}:${{ matrix.distro.tag }}
 
@@ -117,7 +115,7 @@ jobs:
       run: |
         export DEBIAN_FRONTEND=noninteractive
         apt-get update -q
-        apt-get install -qy gcc make linux-headers-generic linux-image-generic openssl shim-signed patch
+        apt-get install -qy gcc make linux-headers-generic linux-image-generic openssl pahole patch shim-signed
         make install-debian
 
     - name: Run tests

--- a/run_test.sh
+++ b/run_test.sh
@@ -389,7 +389,7 @@ fi
 try_sign_modules_file='/etc/dkms/framework.conf.d/try_sign_modules.conf'
 
 # Compute the expected destination module location
-os_id="$(sed -n 's/^ID\s*=\s*\(.*\)$/\1/p' /etc/os-release | tr -d '"')"
+os_id="$(sed -n 's/^ID\s*=\s*\(.*\)$/\1/p' /etc/os-release | tr -d "\"'")"
 distro_sign_file_candidates=
 distro_modsigkey=/var/lib/dkms/mok.key
 distro_modsigcert=/var/lib/dkms/mok.pub


### PR DESCRIPTION
- Drop Alpine 3.20 (EOL).
- Add Fedora 44.
- Add new dependency for Ubuntu on `pahole`.
- Switch to using `ubuntu-latest` for whatever is the latest Ubuntu on the [Github Actions images](https://github.com/actions/runner-images#available-images).
- Adjut parsing of `/etc/os-release` for recent Gentoo changes, as the distribution ID is now wrapped in single quotes.