### PR TITLE
Add deferred logic for BUILD_DEPENDS

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -743,6 +743,34 @@ of another module that is managed by dkms. Do not specify a version or
 architecture in the dependency. A missing dependency requires the parameter
 .OP --force
 to still attempt the build of the module.
+
+When invoked through
+.B autoinstall ,
+unresolved dependencies are handled differently depending on whether they are
+known to dkms. A dependency that is itself a dkms-managed module but failed
+to install (for example because of a circular dependency or a build error)
+is treated as a hard failure and causes
+.B autoinstall
+to exit non-zero. A dependency that is
+.I not
+registered with dkms at the time
+.B autoinstall
+runs is treated as deferred: a warning is emitted and the dependent module is left in the
+.B added
+state, but
+.B autoinstall
+exits successfully. This avoids spurious failures during multi-package
+installs where the dependency's source package has not yet had its postinst
+run, or where the dependency is supplied by something outside dkms. The
+dependent module will be picked up by the next
+.B autoinstall
+trigger once the dependency becomes available.
+
+Example: Ubuntu system with module A and module B depending on A. During an update, both
+the kernel and module A get updated, so
+.B autoinstall
+runs as a kernel post hook. This means the whole dependency logic fails because module A is not
+yet installed to satisfy module B.
 .TP
 .B BUILD_DEPENDS_REBUILD=
 If this directive is set to

--- a/dkms.in
+++ b/dkms.in
@@ -2994,6 +2994,8 @@ autoinstall() {
     local -a installed_modules
     local -a skipped_modules
     local -a failed_modules
+    local -a unresolved_modules
+    local -a deferred_modules
     local -A build_depends
     local -A latest
 
@@ -3104,12 +3106,53 @@ autoinstall() {
         echo "Autoinstall on ${kernelver[0]} failed for module(s) ${failed_modules[*]}."
     fi
 
+    # Classify modules with unresolved BUILD_DEPENDS:
+    #
+    #   "real" missing dependency:
+    #
+    #   The dependency is a DKMS-managed module (in known_modules) that we tried but could
+    #   not install (e.g. circular dependency, build failure of the dependency).
+    #
+    #   "deferred" missing dependency:
+    #
+    #   The dependency is not registered with DKMS at all. This commonly happens during
+    #   multi-package installs where the dependency's source package has not yet been configured
+    #   by dpkg/rpm, so its postinst hasn't run `dkms add` yet. The dependency may also be
+    #   supplied by something outside DKMS entirely. Either way, the current autoinstall run
+    #   cannot make progress on it, but a later trigger (the dependency package's own postinst,
+    #   or a re-run of this hook) will. Don't fail the whole transaction in that case.
+    local d is_known real_missing_deps deferred_deps
     for mv in "${to_install[@]}"; do
         IFS=/ read -r m v <<< "$mv"
-        echo "$m/$v autoinstall failed due to missing dependencies: ${build_depends[$m]}."
+        real_missing_deps=
+        deferred_deps=
+        for d in ${build_depends[$m]}; do
+            is_known=
+            for k in "${known_modules[@]}"; do
+                [[ "$d" = "$k" ]] && { is_known=1; break; }
+            done
+            if [[ $is_known ]]; then
+                real_missing_deps="$real_missing_deps $d"
+            else
+                deferred_deps="$deferred_deps $d"
+            fi
+        done
+        if [[ $real_missing_deps ]]; then
+            echo "$m/$v autoinstall failed due to missing dependencies:$real_missing_deps."
+            unresolved_modules[${#unresolved_modules[@]}]="$mv"
+        else
+            echo "$m/$v autoinstall deferred: BUILD_DEPENDS not registered with DKMS:$deferred_deps."
+            echo "  These may be provided externally or by a package not yet configured;"
+            echo "  autoinstall will retry on the next trigger."
+            deferred_modules[${#deferred_modules[@]}]="$mv"
+        fi
     done
 
-    if (( ${#failed_modules[@]} > 0 || ${#to_install[@]} > 0 )); then
+    if (( ${#deferred_modules[@]} > 0 )); then
+        warn "Autoinstall on ${kernelver[0]} deferred module(s) ${deferred_modules[*]} due to BUILD_DEPENDS not yet registered with DKMS."
+    fi
+
+    if (( ${#failed_modules[@]} > 0 || ${#unresolved_modules[@]} > 0 )); then
         die 11 "One or more modules failed to install during autoinstall." \
             "Refer to previous errors for more information."
     fi

--- a/dkms.in
+++ b/dkms.in
@@ -3142,14 +3142,13 @@ autoinstall() {
             unresolved_modules[${#unresolved_modules[@]}]="$mv"
         else
             echo "$m/$v autoinstall deferred: BUILD_DEPENDS not registered with DKMS:$deferred_deps."
-            echo "  These may be provided externally or by a package not yet configured;"
-            echo "  autoinstall will retry on the next trigger."
             deferred_modules[${#deferred_modules[@]}]="$mv"
         fi
     done
 
     if (( ${#deferred_modules[@]} > 0 )); then
-        warn "Autoinstall on ${kernelver[0]} deferred module(s) ${deferred_modules[*]} due to BUILD_DEPENDS not yet registered with DKMS."
+        echo "Autoinstall on ${kernelver[0]} deferred module(s) ${deferred_modules[*]} due to BUILD_DEPENDS not yet registered with DKMS."
+        echo "These may be provided externally or by a package not yet configured; autoinstall will retry on the next trigger."
     fi
 
     if (( ${#failed_modules[@]} > 0 || ${#unresolved_modules[@]} > 0 )); then

--- a/run_test.sh
+++ b/run_test.sh
@@ -1833,12 +1833,12 @@ run_status_with_expected_output 'dkms_dependencies_test' << EOF
 dkms_dependencies_test/1.0: added
 EOF
 
-echo "Running dkms autoinstall (expected error)"
-run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
-dkms_dependencies_test/1.0 autoinstall failed due to missing dependencies: dkms_test.
-
-Error! One or more modules failed to install during autoinstall.
-Refer to previous errors for more information.
+echo "Running dkms autoinstall (expected deferred, BUILD_DEPENDS not in DKMS)"
+run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+dkms_dependencies_test/1.0 autoinstall deferred: BUILD_DEPENDS not registered with DKMS: dkms_test.
+  These may be provided externally or by a package not yet configured;
+  autoinstall will retry on the next trigger.
+Warning: Autoinstall on ${KERNEL_VER} deferred module(s) dkms_dependencies_test/1.0 due to BUILD_DEPENDS not yet registered with DKMS.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 EOF
@@ -2285,12 +2285,12 @@ run_status_with_expected_output 'dkms_dependencies_rebuild_test' << EOF
 dkms_dependencies_rebuild_test/1.0: added
 EOF
 
-echo "Running dkms autoinstall (expected error)"
-run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
-dkms_dependencies_rebuild_test/1.0 autoinstall failed due to missing dependencies: dkms_test.
-
-Error! One or more modules failed to install during autoinstall.
-Refer to previous errors for more information.
+echo "Running dkms autoinstall (expected deferred, BUILD_DEPENDS not in DKMS)"
+run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+dkms_dependencies_rebuild_test/1.0 autoinstall deferred: BUILD_DEPENDS not registered with DKMS: dkms_test.
+  These may be provided externally or by a package not yet configured;
+  autoinstall will retry on the next trigger.
+Warning: Autoinstall on ${KERNEL_VER} deferred module(s) dkms_dependencies_rebuild_test/1.0 due to BUILD_DEPENDS not yet registered with DKMS.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 EOF

--- a/run_test.sh
+++ b/run_test.sh
@@ -37,6 +37,7 @@ TEST_MODULES=(
     "dkms_noautoinstall_test"
     "dkms_failing_test"
     "dkms_failing_dependencies_test"
+    "dkms_dependencies_on_noautoinstall_test"
     "dkms_multiver_test"
     "dkms_nover_test"
     "dkms_emptyver_test"
@@ -3843,6 +3844,54 @@ Deleting module dkms_failing_dependencies_test/1.0 completely from the DKMS tree
 EOF
 
 remove_module_source_tree /usr/src/dkms_failing_dependencies_test-1.0
+
+# Negative test: BUILD_DEPENDS points to a module that is registered with DKMS
+# but won't be installed automatically (AUTOINSTALL=""). Because the dep IS
+# known to DKMS, this is a *real* missing-dependency case (not a deferred one)
+# and autoinstall must fail with code 11.
+echo 'Adding noautoinstall test module (will be the unsatisfiable BUILD_DEPENDS)'
+run_with_expected_output dkms add test/dkms_noautoinstall_test-1.0 << EOF
+Creating symlink /var/lib/dkms/dkms_noautoinstall_test/1.0/source -> /usr/src/dkms_noautoinstall_test-1.0
+EOF
+check_module_source_tree_created /usr/src/dkms_noautoinstall_test-1.0
+
+echo 'Adding test module with BUILD_DEPENDS on the noautoinstall module'
+run_with_expected_output dkms add test/dkms_dependencies_on_noautoinstall_test-1.0 << EOF
+Creating symlink /var/lib/dkms/dkms_dependencies_on_noautoinstall_test/1.0/source -> /usr/src/dkms_dependencies_on_noautoinstall_test-1.0
+EOF
+check_module_source_tree_created /usr/src/dkms_dependencies_on_noautoinstall_test-1.0
+
+echo 'Running autoinstall with BUILD_DEPENDS on a known-but-not-autoinstalled module (expected error)'
+run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
+dkms_dependencies_on_noautoinstall_test/1.0 autoinstall failed due to missing dependencies: dkms_noautoinstall_test.
+
+Error! One or more modules failed to install during autoinstall.
+Refer to previous errors for more information.
+EOF
+run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
+dkms_noautoinstall_test/1.0: added
+EOF
+run_status_with_expected_output 'dkms_dependencies_on_noautoinstall_test' << EOF
+dkms_dependencies_on_noautoinstall_test/1.0: added
+EOF
+
+echo 'Removing the dependent test module'
+run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_dependencies_on_noautoinstall_test -v 1.0 << EOF
+Module dkms_dependencies_on_noautoinstall_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
+Module dkms_dependencies_on_noautoinstall_test/1.0 is not built for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
+
+Deleting module dkms_dependencies_on_noautoinstall_test/1.0 completely from the DKMS tree.
+EOF
+remove_module_source_tree /usr/src/dkms_dependencies_on_noautoinstall_test-1.0
+
+echo 'Removing the noautoinstall test module'
+run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_noautoinstall_test -v 1.0 << EOF
+Module dkms_noautoinstall_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
+Module dkms_noautoinstall_test/1.0 is not built for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
+
+Deleting module dkms_noautoinstall_test/1.0 completely from the DKMS tree.
+EOF
+remove_module_source_tree /usr/src/dkms_noautoinstall_test-1.0
 
 echo 'Checking that the environment is clean again'
 check_no_dkms_test

--- a/run_test.sh
+++ b/run_test.sh
@@ -1836,9 +1836,8 @@ EOF
 echo "Running dkms autoinstall (expected deferred, BUILD_DEPENDS not in DKMS)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 dkms_dependencies_test/1.0 autoinstall deferred: BUILD_DEPENDS not registered with DKMS: dkms_test.
-  These may be provided externally or by a package not yet configured;
-  autoinstall will retry on the next trigger.
-Warning: Autoinstall on ${KERNEL_VER} deferred module(s) dkms_dependencies_test/1.0 due to BUILD_DEPENDS not yet registered with DKMS.
+Autoinstall on ${KERNEL_VER} deferred module(s) dkms_dependencies_test/1.0 due to BUILD_DEPENDS not yet registered with DKMS.
+These may be provided externally or by a package not yet configured; autoinstall will retry on the next trigger.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 EOF
@@ -2288,9 +2287,8 @@ EOF
 echo "Running dkms autoinstall (expected deferred, BUILD_DEPENDS not in DKMS)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 dkms_dependencies_rebuild_test/1.0 autoinstall deferred: BUILD_DEPENDS not registered with DKMS: dkms_test.
-  These may be provided externally or by a package not yet configured;
-  autoinstall will retry on the next trigger.
-Warning: Autoinstall on ${KERNEL_VER} deferred module(s) dkms_dependencies_rebuild_test/1.0 due to BUILD_DEPENDS not yet registered with DKMS.
+Autoinstall on ${KERNEL_VER} deferred module(s) dkms_dependencies_rebuild_test/1.0 due to BUILD_DEPENDS not yet registered with DKMS.
+These may be provided externally or by a package not yet configured; autoinstall will retry on the next trigger.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 EOF

--- a/test/dkms_dependencies_on_noautoinstall_test-1.0/Makefile
+++ b/test/dkms_dependencies_on_noautoinstall_test-1.0/Makefile
@@ -1,0 +1,3 @@
+all:
+	@echo ERROR: This module should never build during the negative autoinstall test.
+	@exit 1

--- a/test/dkms_dependencies_on_noautoinstall_test-1.0/dkms.conf
+++ b/test/dkms_dependencies_on_noautoinstall_test-1.0/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="dkms_dependencies_on_noautoinstall_test"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME[0]="dkms_dependencies_on_noautoinstall_test"
+DEST_MODULE_LOCATION[0]="/kernel/extra"
+BUILD_DEPENDS="dkms_noautoinstall_test"
+MAKE="make all"
+AUTOINSTALL="yes"


### PR DESCRIPTION
Add deferred logic for `BUILD_DEPENDS` with multiple package upgrades (kernel, modules and dependent modules) when invoking `autoinstall`. 

### The issue

Practical issue in Ubuntu:

1. Module with a dependency specified:
```
$ cat /usr/src/nvidia-fs-2.26.6/dkms.conf | grep BUILD_DEPENDS
BUILD_DEPENDS[0]="nvidia"
```

2.  A transaction involving an update of the kernel and the `nvidia` DKMS module at the same time:
```
Autoinstall on 6.14.0-1011-nvidia-64k succeeded for module(s) kernel-mft-dkms knem mlnx-ofed-kernel xpmem.
nvidia-fs/2.26.6 autoinstall failed due to missing dependencies: nvidia.

Error! One or more modules failed to install during autoinstall.
Refer to previous errors for more information.
run-parts: /etc/kernel/header_postinst.d/dkms exited with return code 1
dpkg: error processing package linux-headers-6.14.0-1011-nvidia-64k (--configure):
 installed linux-headers-6.14.0-1011-nvidia-64k package post-installation script subprocess returned error exit status 1
```

3. At the end of the upgrade, DKMS triggers a rebuild of `nvidia-fs`, which now succeeds because the `nvidia` module has now been built:
```
Autoinstall of module nvidia-fs/2.26.6 for kernel 6.14.0-1011-nvidia-64k (aarch64)
Building module(s).......... done.
Signing module /var/lib/dkms/nvidia-fs/2.26.6/build/nvidia-fs.ko
Found pre-existing /lib/modules/6.14.0-1011-nvidia-64k/ubuntu/nvidia-fs/nvidia-fs.ko.zst, archiving for uninstallation
Installing /lib/modules/6.14.0-1011-nvidia-64k/updates/dkms/nvidia-fs.ko.zst
Running depmod... done.

Autoinstall on 6.14.0-1011-nvidia-64k succeeded for module(s) iser isert kernel-mft-dkms knem mlnx-nfsrdma mlnx-nvme mlnx-ofed-kernel nvidia srp xpmem nvidia-fs.
```

But at this point, the initial failure causes the `apt` transaction to report a failure:
```
Errors were encountered while processing:
 linux-headers-6.14.0-1011-nvidia-64k
 linux-headers-nvidia-64k-6.14
 linux-nvidia-64k-6.14
```

### Deferred logic for hard dependencies

`autoinstall` now distinguishes two kinds of unresolved `BUILD_DEPENDS` (taken from the comments in `dkms.in`):

- "real" missing dependency:
  The dependency is a DKMS-managed module (in `known_modules`) that we tried but could not install (e.g. circular dependency, build failure of the dependency).

- "deferred" missing dependency:
  The dependency is not registered with DKMS at all. This commonly happens during multi-package installs where the dependency's source package has not yet been configured by `dpkg/rpm`, so its `postinst` hasn't run `dkms add` yet. The dependency may also be supplied by something outside DKMS entirely. Either way, the current `autoinstall` run  cannot make progress on it, but a later trigger (the dependency package's own `postinst`, or a re-run of this hook) will. Don't fail the whole transaction in that case.

By running `dkms build` directly, as it was before, exit 13 is still returned unless `--force` is used. The relaxation (the deferred logic) is only on the automated path where DKMS doesn't have full visibility into pending package operations.