### PR TITLE
Add stale issue management

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Mark stale issues
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 180
+          days-before-issue-close: 30
+          exempt-issue-labels: 'enhancement,bug'
+          stale-issue-message: >
+            This issue has been automatically marked as stale due to inactivity.
+            Please try to reproduce on the latest version of DKMS and update
+            with any up to date information.
+          close-issue-message: >
+            Closing this issue due to prolonged inactivity. If you are still
+            experiencing the issue, please reproduce it on the latest version
+            of DKMS and open a new issue with up to date information.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
- Runs weekly
- Excludes items marked with `bug` or `enhancement`.
- Notifies after 6 months of inactivity.
- Closes the issue after another month of inactivity.