### PR TITLE
dkms: Use a generic missing kernel headers error message

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1285,7 +1285,7 @@ prepare_kernel()
     # Check that kernel-source exists
     _check_kernel_dir "$1" || {
         die 21 "Your kernel headers for kernel $1 cannot be found at $install_tree/$1/build or $install_tree/$1/source." \
-            "Please install the linux-headers-$1 package or use the --kernelsourcedir option to tell DKMS where it's located."
+            "Please install your distribution's kernel headers package matching $1, or use the --kernelsourcedir option to tell DKMS where it's located."
     }
 }
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -600,7 +600,7 @@ echo 'Building the test module for a kernel without headers installed (expected 
 run_with_expected_error 21 dkms build -k "${KERNEL_VER}-noheaders" -m dkms_test -v 1.0 << EOF
 
 Error! Your kernel headers for kernel ${KERNEL_VER}-noheaders cannot be found at /lib/modules/${KERNEL_VER}-noheaders/build or /lib/modules/${KERNEL_VER}-noheaders/source.
-Please install the linux-headers-${KERNEL_VER}-noheaders package or use the --kernelsourcedir option to tell DKMS where it's located.
+Please install your distribution's kernel headers package matching ${KERNEL_VER}-noheaders, or use the --kernelsourcedir option to tell DKMS where it's located.
 EOF
 
 echo 'Building the test module for more than one kernel version (same version twice for this test)'
@@ -1191,7 +1191,7 @@ echo ' Running dkms autoinstall (expected error)'
 run_with_expected_error 21 dkms autoinstall -k "${KERNEL_VER}-noheaders" << EOF
 
 Error! Your kernel headers for kernel ${KERNEL_VER}-noheaders cannot be found at /lib/modules/${KERNEL_VER}-noheaders/build or /lib/modules/${KERNEL_VER}-noheaders/source.
-Please install the linux-headers-${KERNEL_VER}-noheaders package or use the --kernelsourcedir option to tell DKMS where it's located.
+Please install your distribution's kernel headers package matching ${KERNEL_VER}-noheaders, or use the --kernelsourcedir option to tell DKMS where it's located.
 EOF
 
 if [[ -x /usr/lib/dkms/dkms_autoinstaller ]]; then
@@ -1205,7 +1205,7 @@ echo ' Running dkms kernel_postinst (expected error)'
 run_with_expected_error 21 dkms kernel_postinst -k "${KERNEL_VER}-noheaders" << EOF
 
 Error! Your kernel headers for kernel ${KERNEL_VER}-noheaders cannot be found at /lib/modules/${KERNEL_VER}-noheaders/build or /lib/modules/${KERNEL_VER}-noheaders/source.
-Please install the linux-headers-${KERNEL_VER}-noheaders package or use the --kernelsourcedir option to tell DKMS where it's located.
+Please install your distribution's kernel headers package matching ${KERNEL_VER}-noheaders, or use the --kernelsourcedir option to tell DKMS where it's located.
 EOF
 
 echo ' Running dkms kernel_prerm'


### PR DESCRIPTION
The missing kernel headers error only suggested the Debian-style linux-headers package.
Add the rpm-based kernel-devel package to make the DKMS guidance useful across packaging ecosystems, and update the expected test output accordingly.