### PR TITLE
Adjust module location matches

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -513,7 +513,7 @@ override_dest_module_location()
     [[ ${addon_modules_dir} ]] && echo "/${addon_modules_dir}" && return
 
     case "$running_distribution" in
-    fedora* | rhel* | ovm*)
+    fedora* | centos* | rhel*)
         echo "/extra" && return
         ;;
     sles* | suse* | opensuse*)


### PR DESCRIPTION
Fixes https://github.com/dkms-project/dkms/issues/595.

Be more explicit with distribution matching for the Red Hat case: `fedora/centos/rhel`.

Drop `ovm`, it's dead now.